### PR TITLE
Add security permission for settings

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -26,7 +26,8 @@ class Plugin extends PluginBase
                 'url'         => Backend::url('romanov/flashmessage/settings'),
                 'order'       => 501,
                 'category'    => 'system::lang.system.categories.cms',
-                'keywords'    => 'flash message'
+                'keywords'    => 'flash message',
+                'permissions' => ['romanov.flashmessage.editconfigurations']
             ]
         ];
     }

--- a/controllers/Settings.php
+++ b/controllers/Settings.php
@@ -14,6 +14,10 @@ class Settings extends Controller
     public $formConfig = 'config_form.yaml';
     public $listConfig = 'config_list.yaml';
 
+    public $requiredPermissions = [
+        'romanov.flashmessage.editconfigurations'
+    ];
+
     public function __construct()
     {
         parent::__construct();

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,0 +1,4 @@
+permissions:
+    romanov.flashmessage.editconfigurations:
+        tab: 'Flash message'
+        label: 'Manage Flash Message configurations'

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -6,4 +6,5 @@
   - Fix some bug with Rainlab.User login form errors
 1.0.3:
   - fastfix
-  
+1.0.4:
+  - Add security permission for settings page


### PR DESCRIPTION
These changes add a security permission to control access to the settings, so they don't have to be available to all backend users.